### PR TITLE
remove __unused to prevent older glibc conflict

### DIFF
--- a/libterminfo/cdbr.c
+++ b/libterminfo/cdbr.c
@@ -112,8 +112,9 @@ struct cdbr {
 
 #if !defined(_KERNEL) && !defined(_STANDALONE)
 static void
-cdbr_unmap(void *cookie __unused, void *base, size_t size)
+cdbr_unmap(void *cookie, void *base, size_t size)
 {
+	(void)cookie;
 	munmap(base, size);
 }
 

--- a/libterminfo/termcap.c
+++ b/libterminfo/termcap.c
@@ -49,8 +49,9 @@ char *BC;
 
 /* ARGSUSED */
 int
-tgetent(__unused char *bp, const char *name)
+tgetent(char *bp, const char *name)
 {
+	(void)bp;
 	int errret;
 	static TERMINAL *last = NULL;
 

--- a/netbsd_sys/cdefs.h
+++ b/netbsd_sys/cdefs.h
@@ -6,7 +6,6 @@
 #define __BEGIN_DECLS
 #define __END_DECLS
 #endif
-#define __unused
 #define __COPYRIGHT(X)
 
 #ifndef __printflike


### PR DESCRIPTION
Hi there - I had a problem building netbsd-curses on CentOS 6 (which uses glibc-2.12).

The netbsd cdefs have a `#define __unused`, which conflicts with a later include from glibc.
