### PR TITLE
Prevent clear.sh from overwriting userland's clear

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -183,7 +183,7 @@ install-tset: tset/tset
 
 install-tput: tput/tput tput/clear.sh
 	$(INSTALL) -Dm 755 tput/tput $(DESTDIR)$(BINDIR)/tput
-	$(INSTALL) -Dm 755 tput/clear.sh $(DESTDIR)$(BINDIR)/clear
+	$(INSTALL) -Dm 755 tput/clear.sh $(DESTDIR)$(BINDIR)/clear.sh
 
 install-infocmp: infocmp/infocmp
 	$(INSTALL) -Dm 755 infocmp/infocmp $(DESTDIR)$(BINDIR)/infocmp


### PR DESCRIPTION
Apparently userland's `clear` command is being overwritten by `tput/clear.sh` after running a `make install`:

```Shell
	$(INSTALL) -Dm 755 tput/clear.sh $(DESTDIR)$(BINDIR)/clear
```

This prevents that from happening simply by appending a `.sh` to the target `clear`.