### PR TITLE
option to merge libterminfo objects into libcurses

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,7 +127,7 @@ PA_MAN =$(sort $(wildcard libpanel/*.3))
 
 ME_SRCS_=menu.c item.c userptr.c internals.c driver.c post.c attributes.c
 ME_MAN = $(sort $(wildcard libmenu/*.3))
-ME_SRCS=$(patsubst %,libmenu/%,$(ME_SRCuiS_))
+ME_SRCS=$(patsubst %,libmenu/%,$(ME_SRCS_))
 ME_INCS=libmenu/menu.h libmenu/eti.h
 ME_OBJS=$(ME_SRCS:.c=.o)
 ME_LIBA=libmenu/libmenu.a

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -103,7 +103,7 @@ CPPFLAGS+=-DDISABLE_WCHAR
 endif
 
 ifdef MERGE_TERMINFO
-CU_SRCS_+=$(TI_SRCS)
+CU_SRCS_+=$(subst libterminfo/,../libterminfo/,$(TI_SRCS))
 endif
 
 CU_SRCS=$(patsubst %,libcurses/%,$(CU_SRCS_))
@@ -127,7 +127,7 @@ PA_MAN =$(sort $(wildcard libpanel/*.3))
 
 ME_SRCS_=menu.c item.c userptr.c internals.c driver.c post.c attributes.c
 ME_MAN = $(sort $(wildcard libmenu/*.3))
-ME_SRCS=$(patsubst %,libmenu/%,$(ME_SRCS_))
+ME_SRCS=$(patsubst %,libmenu/%,$(ME_SRCuiS_))
 ME_INCS=libmenu/menu.h libmenu/eti.h
 ME_OBJS=$(ME_SRCS:.c=.o)
 ME_LIBA=libmenu/libmenu.a

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ link to both libcurses and libterminfo.
 with these instructions it is easy to compile the majority of ncurses apps
 without problems against netbsd-curses.
 
+An alternative is to compile netbsd-curses with the option MERGE_TERMINFO=1,
+which will include the libterminfo objects in libcurses.
+
 a small percentage of apps written for ncurses poke at internals and need
 light patching:
 


### PR DESCRIPTION
An optional merge of the libterminfo objects into libcurses, and not building libterminfo (perhaps an empty file or symlink should be installed for backwards compatibility?)

Discussed in issue #43 