### PR TITLE
libpanel.so: Fix a build break without an already installed libterminfo.so

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -526,7 +526,7 @@ $(PA_LIBA): $(PA_OBJS)
 
 $(PA_LIBSO): $(CU_LIBSO)
 $(PA_LIBSO): $(PA_LOBJS)
-	$(CC) -shared -o $@ $^ -Wl,-soname=$(notdir $@)
+	$(CC) -shared -L./libterminfo -o $@ $^ -Wl,-soname=$(notdir $@)
 
 $(ME_LIBA): $(ME_OBJS)
 	rm -f $@


### PR DESCRIPTION
While testing the new rc of tinycc on linux, the build breaks at libpanel/libpanel.so:
* libpanel/libpanel.so depends on libcurses/libcurses.so

* libcurses/libcurses.so depends on libterminfo/libterminfo.so
* the compiler searches for libterminfo.so, but fails:

```
tcc -m32 -w  -v -v  -shared -o libpanel/libpanel.so libpanel/_deck.lo libpanel/above.lo libpanel/below.lo libpanel/bottom.lo libpanel/del.lo libpanel/getuser.lo libpanel/hidden.lo libpanel/hide.lo libpanel/move.lo libpanel/new.lo libpanel/replace.lo libpanel/setuser.lo libpanel/show.lo libpanel/top.lo libpanel/update.lo libpanel/window.lo libcurses/libcurses.so -Wl,-soname=libpanel.so
tcc version 0.9.28rc 2023-09-09 mob@7f39b4f (i386 Linux)
-> /usr/i686-linux-gnu/lib/crti.o
-> libpanel/_deck.lo
-> libpanel/above.lo
-> libpanel/below.lo
-> libpanel/bottom.lo
-> libpanel/del.lo
-> libpanel/getuser.lo
-> libpanel/hidden.lo
-> libpanel/hide.lo
-> libpanel/move.lo
-> libpanel/new.lo
-> libpanel/replace.lo
-> libpanel/setuser.lo
-> libpanel/show.lo
-> libpanel/top.lo
-> libpanel/update.lo
-> libpanel/window.lo
-> libcurses/libcurses.so
libcurses/libcurses.so: error: referenced dll 'libterminfo.so' not found
make: *** [GNUmakefile:529: libpanel/libpanel.so] Fehler 1
```

This patch adds the missing reference to libterminfo/
during the build to allow the compiler to find libterminfo.so.

When the os has a libterminfo.so already installed in one of the
default lib search directories, the bug will never be visible.

This can be verified after a sucessful build,
without an installed libterminfo.so:
Example:
```
ldd libpanel/libpanel.so
libcurses.so is marked as "not found"

ldd libcurses/libcurses.so
libterminfo.so is marked as "not found"
```


-- 
Regards ... Detlef
