### PR TITLE
Sleeping on reset is behavoir from physical terminals that's been outdated since the 90s at latest

### DIFF
--- a/tset/set.c
+++ b/tset/set.c
@@ -236,7 +236,6 @@ set_init(void)
 	if (settle) {
 		(void)putc('\r', stderr);
 		(void)fflush(stderr);
-		(void)sleep(1);			/* Settle the terminal. */
 	}
 }
 


### PR DESCRIPTION
Sleeping on reset/initialization only makes sense if you need to give time for a physical terminal to work. Since every terminal since the 90s has been emulated in some form. This code is more than deprecated enough to strip it out